### PR TITLE
Fix interceptor discovery for GET parameters

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,10 +24,7 @@ export function disable_net_connect() {
 }
 
 export function play_nocks(dirname: string) {
-  const records = load_records(dirname).map(record => ({
-    ...record,
-    options: { allowUnmocked: true },
-  }));
+  const records = load_records(dirname);
   nock.define(records).forEach(scope => scope.persist());
 }
 


### PR DESCRIPTION
I am currently trying to integrate your (btw. amazing and amazingly simple) tool into a large code base for mocking a large quantity of API calls. I discovered that for some reason some of the calls were not intercepted and could track it down to the interceptor failing in case there are GET parameters in the request URL and the allow_unmocked option is set. I haven't had time yet to check further but simply removing this bit makes all tests work for me here...