### PR TITLE
Allow enableNetConnect to provide a matcher for partially enabling requests

### DIFF
--- a/src/nock.ts
+++ b/src/nock.ts
@@ -12,7 +12,7 @@ export function deactivate() {
   nock.cleanAll();
 }
 
-export function enableNetConnect(matcher?: string | RegExp | ((host: string) => boolean)) {
+export function enableNetConnect(matcher?: string | RegExp | ((host: string) => boolean),) {
   nock.enableNetConnect(matcher);
 }
 

--- a/src/nock.ts
+++ b/src/nock.ts
@@ -12,8 +12,8 @@ export function deactivate() {
   nock.cleanAll();
 }
 
-export function enableNetConnect() {
-  nock.enableNetConnect();
+export function enableNetConnect(matcher?: string | RegExp | ((host: string) => boolean)) {
+  nock.enableNetConnect(matcher);
 }
 
 export function disableNetConnect() {


### PR DESCRIPTION
Mostly so I can use supertest to test my express server.

https://github.com/nock/nock#enabling-requests
https://github.com/nock/nock/blob/64de45c043369f77bfee1be89ab96bd4cb7cfee7/types/index.d.ts#L24