### PR TITLE
feat: support specifying mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,33 +15,52 @@ npm install jest-playback
 
 ## Usage
 
-In setup file or test file:
-
 ```js
-import setupPlayback from 'jest-playback'
-await setupPlayback()
+import * as jestPlayback from 'jest-playback'
+
+await jestPlayback.setup()
+
+test('example', async () => {
+  const response = await fetch('http://www.example.com/')
+  expect(response.status).toBe(200)
+})
 ```
 
-The HTTP responses are stored as snapshots:
-
-- default
-  - new requests will be stored
-  - stored records will be played
-- with Jest `--ci` flag specified
-  - new requests will be blocked
-  - stored records will be played
-- with Jest `--update-snapshot` flag specified
-  - new requests will be stored
-  - stored records will be updated
-  - obsolete records will be removed
+The records are stored as snapshots.
 
 ## API
 
 ```ts
-declare function setupPlayback(options?: Options): Promise<void>
+export default setup
+export declare function setup(options?: Options): Promise<void>
 
-interface Options {
+export interface Options {
+  /** @default Mode.Auto */
+  mode?: Mode
   getRequestCacheKey?: (request: Request) => string | Promise<string>
+}
+
+export enum Mode {
+  /**
+   * - `Mode.Update` if Jest `--update-snapshot` flag specified
+   * - `Mode.Play` if Jest `--ci` flag specified
+   * - `Mode.Record` otherwise
+   */
+  Auto = 'auto',
+  /**
+   * - all requests are recorded
+   */
+  Update = 'update',
+  /**
+   * - play records
+   * - new requests are blocked
+   */
+  Play = 'play',
+  /**
+   * - play records
+   * - new requests are recorded
+   */
+  Record = 'record',
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,7 @@
-import { BatchInterceptor } from '@mswjs/interceptors'
-import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
-import { FetchInterceptor } from '@mswjs/interceptors/fetch'
-import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
-import { PlaybackManager } from './manager.js'
+import { Mode } from './modes.js'
 import { Options } from './options.js'
-import { JestRunner, VitestRunner } from './runners/index.js'
+import { setup } from './setup.js'
 
-export default async function setup(options?: Options) {
-  const runner = getRunner()
-  await runner.init()
-  const manager = new PlaybackManager(runner, options)
-  const interceptor = new BatchInterceptor({
-    name: 'interceptor',
-    interceptors: [
-      new ClientRequestInterceptor(),
-      new FetchInterceptor(),
-      new XMLHttpRequestInterceptor(),
-    ],
-  })
-  interceptor.apply()
-  interceptor.on('request', async ({ request }) => {
-    const response = await manager.onRequest(request)
-    if (response) {
-      request.respondWith(response)
-    }
-  })
-}
-
-function getRunner() {
-  if ('JEST_WORKER_ID' in process.env) {
-    return new JestRunner()
-  }
-  if ('VITEST_POOL_ID' in process.env) {
-    return new VitestRunner()
-  }
-  throw new Error('unexpected environment')
-}
+export type { Options }
+export { setup, Mode }
+export default setup

--- a/src/modes.ts
+++ b/src/modes.ts
@@ -1,0 +1,22 @@
+export enum Mode {
+  /**
+   * - `Mode.Update` if Jest `--update-snapshot` flag specified
+   * - `Mode.Play` if Jest `--ci` flag specified
+   * - `Mode.Record` otherwise
+   */
+  Auto = 'auto',
+  /**
+   * - all requests are recorded
+   */
+  Update = 'update',
+  /**
+   * - play records
+   * - new requests are blocked
+   */
+  Play = 'play',
+  /**
+   * - play records
+   * - new requests are recorded
+   */
+  Record = 'record',
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,9 @@
 import crypto from 'node:crypto'
+import { Mode } from './modes.js'
 
 export interface Options {
+  /** @default Mode.Auto */
+  mode?: Mode
   getRequestCacheKey?: (request: Request) => string | Promise<string>
 }
 

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -19,7 +19,7 @@ interface SnapshotState {
   _updateSnapshot: SnapshotUpdateState
 }
 
-type SnapshotUpdateState = 'all' | 'new' | 'none'
+export type SnapshotUpdateState = 'all' | 'new' | 'none'
 type SnapshotData = Record<string, string>
 
 interface PrettyFormatPlugin {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,38 @@
+import { BatchInterceptor } from '@mswjs/interceptors'
+import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+import { PlaybackManager } from './manager.js'
+import { Options } from './options.js'
+import { JestRunner, VitestRunner } from './runners/index.js'
+
+export async function setup(options?: Options) {
+  const runner = getRunner()
+  await runner.init()
+  const manager = new PlaybackManager(runner, options)
+  const interceptor = new BatchInterceptor({
+    name: 'interceptor',
+    interceptors: [
+      new ClientRequestInterceptor(),
+      new FetchInterceptor(),
+      new XMLHttpRequestInterceptor(),
+    ],
+  })
+  interceptor.apply()
+  interceptor.on('request', async ({ request }) => {
+    const response = await manager.onRequest(request)
+    if (response) {
+      request.respondWith(response)
+    }
+  })
+}
+
+function getRunner() {
+  if ('JEST_WORKER_ID' in process.env) {
+    return new JestRunner()
+  }
+  if ('VITEST_POOL_ID' in process.env) {
+    return new VitestRunner()
+  }
+  throw new Error('unexpected environment')
+}


### PR DESCRIPTION
- `auto` (default)
  - `update` if Jest `--update-snapshot` flag specified
  - `play` if Jest `--ci` flag specified
  - `record` otherwise
- `update`
  - all requests are recorded
- `play`
  - play records
  - new requests are blocked
- `record`
  - play records
  - new requests are recorded
